### PR TITLE
FEAT:configure postfixadmin via env variables

### DIFF
--- a/config/php/php.conf
+++ b/config/php/php.conf
@@ -1,0 +1,10 @@
+[www]
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+clear_env = no

--- a/config/postfixadmin/config.local.php
+++ b/config/postfixadmin/config.local.php
@@ -1,7 +1,7 @@
 <?php
-$CONF['database_type'] = 'sqlite';
-$CONF['database_name'] = '/etc/postfix/sqlite/postfixadmin.db';
+$CONF['database_type'] = getenv('POSTFIXADMIN_DB_TYPE');
+$CONF['database_name'] = getenv('POSTFIXADMIN_DB_HOST');
 
-$CONF['setup_password'] = '9aaddf10eaca196b343f17ca5de9a886:8a051a4b7876fe321d5ae47271bc17b1327ada60';
+$CONF['setup_password'] = getenv('POSTFIXADMIN_SETUP_PASSWORD');
 
-$CONF['configured'] = true;
+$CONF['configured'] = getenv('POSTFIXADMIN_SETUP_PASSWORD') != '';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,17 @@ services:
   mailship:
     build: .
     image: behringer24/mailship
+    environment: 
+      - POSTFIXADMIN_SETUP_PASSWORD=9aaddf10eaca196b343f17ca5de9a886:8a051a4b7876fe321d5ae47271bc17b1327ada60
     volumes:
+      - mail_dir:/var/vmail
       - spool_mail:/var/spool/mail
       - spool_postfix:/var/spool/postfix
       - sqlite:/etc/postfix/sqlite
+# Uncomment to use postfixadmin behind a reverse proxy but
+# expose the mail ports directly
+#    expose:
+#      - 80:
     ports:
       - "80:80"
       - "25:25"
@@ -21,6 +28,7 @@ services:
     container_name: mailship
 
 volumes:
+  mail_dir:
   spool_mail:
   spool_postfix:
   sqlite:


### PR DESCRIPTION
Making postfixadmin config agnostic to env variables. Had to reconfigure php-fpm worker pool to allow passing of env to PHP