### PR TITLE
Updating postfixadmin to 3.3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir /run/php \
     && chown -R www-data:www-data ${SQLITE_PATH}
 
 # Install postfixadmin from source and extract to docroot
-RUN wget -q -O - "https://github.com/postfixadmin/postfixadmin/archive/postfixadmin-3.2.3.tar.gz" \
+RUN wget -q -O - "https://github.com/postfixadmin/postfixadmin/archive/refs/tags/postfixadmin-3.3.10.tar.gz" \
      | tar -xvzf - -C /var/www/html --strip-components=1 \
     && mkdir /var/www/html/templates_c \
     && chown -R www-data:www-data /var/www/html/templates_c 

--- a/README.md
+++ b/README.md
@@ -91,4 +91,6 @@ services:
 [...]
 ```
 
+IMPORTANT: Postfixadmin since version 3 generates Hashes with '$'. You have to make them double $ so it works in the docker-compose.yml! Every $ in the hash must be changed to $$. Otherwise you get an error when you do docker-compose up -d
+  
 Now go to your <postfixadmin domain>/setup.php again and set up an admin account. after that you can go to /login.php and start configuring your server.


### PR DESCRIPTION
Postfixadmin 3.2.3 occasionally had SQL errors with SQLite. The new version fixes that.